### PR TITLE
added autoload cookie

### DIFF
--- a/tomatinho.el
+++ b/tomatinho.el
@@ -203,6 +203,7 @@
 ;; Main function ;;
 ;;;;;;;;;;;;;;;;;;;
 
+;;;###autoload
 (defun tomatinho ()
   "A simple and beautiful pomodoro technique timer."
   (interactive)


### PR DESCRIPTION
Hi, added a simple oneliner that allows tomatinho to be installed properly via el-get.

Without the autoload cookie, I had to install tomatinho, eval the buffer and only then was I able to use it.

Thanks
