### PR TITLE
Fix package

### DIFF
--- a/tomatinho.el
+++ b/tomatinho.el
@@ -25,7 +25,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(eval-when-compile (require 'cl))
 
 (defvar tomatinho-buffer "Tomatinho!")
 (defvar tomatinho-format "%H:%M:%S")

--- a/tomatinho.el
+++ b/tomatinho.el
@@ -113,7 +113,7 @@
 
 (defun timestamp ()
   "Returns the timestamp as an integer."
-  (string-to-int (format-time-string "%s")))
+  (string-to-number (format-time-string "%s")))
 
 (defun play-sound-file-async (file)
   "Plys with some overhead, but at least doesn't freeze Emacs."

--- a/tomatinho.el
+++ b/tomatinho.el
@@ -227,6 +227,7 @@
 ;; Main function ;;
 ;;;;;;;;;;;;;;;;;;;
 
+;;;###autoload
 (defun tomatinho ()
   "A simple and beautiful pomodoro technique timer."
   (interactive)


### PR DESCRIPTION
- Add autoload cookie for lazy loading
- Don't use deprecated API `string-to-int`
- Load cl.el only at compile-time because this package uses only cl macros.