### PR TITLE
added tomatinho-update-hook (for notifications)

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,9 +47,11 @@ You can set =tomatinho-update-hook= to show desired notification.
 Example using =notify-send=:
 
 #+BEGIN_SRC lisp
+
 (defun my-tomatinho-update-hook ()
   (play-sound-file-async tomatinho-sound-tick) ;; play tick sound every second
-  (when (equal (car tomatinho-current) 'pause)
+  (when (and (equal (car tomatinho-current) 'pause)
+             (= (timestamp) tomatinho-last))
     (start-process "notify-send"
                    nil
                    "notify-send"

--- a/README.org
+++ b/README.org
@@ -41,6 +41,27 @@ settings to your liking.
 
 Some more customs might be added in the future.
 
+* Notification
+You can set =tomatinho-update-hook= to show desired notification.
+
+Example using =notify-send=:
+
+#+BEGIN_SRC lisp
+(defun my-tomatinho-update-hook ()
+  (when (equal (car tomatinho-current) 'pause)
+    (start-process "notify-send"
+                   nil
+                   "notify-send"
+                   (format "tomatinho: make a pause (%s+%s)"
+                           tomatinho-pomodoro-length
+                           (cdr tomatinho-current))
+                   "-t" "3000"
+                   "-i" "/usr/share/icons/hicolor/16x16/apps/emacs.png")))
+
+(add-hook 'tomatinho-update-hook #'my-tomatinho-update-hook)
+#+END_SRC
+
+
 * Seeing is believing
 
   Check out these screenshots!

--- a/README.org
+++ b/README.org
@@ -48,6 +48,7 @@ Example using =notify-send=:
 
 #+BEGIN_SRC lisp
 (defun my-tomatinho-update-hook ()
+  (play-sound-file-async tomatinho-sound-tick) ;; play tick sound every second
   (when (equal (car tomatinho-current) 'pause)
     (start-process "notify-send"
                    nil

--- a/tomatinho.el
+++ b/tomatinho.el
@@ -69,6 +69,8 @@
 (defvar tomatinho-sound-tack (expand-file-name (concat tomatinho-dir "tack.wav"))
   "Tack sound during a break.")
 
+(defvar tomatinho-update-hook nil)
+
 
 ;;; Faces
 ;; §later: classes for dark/light!
@@ -291,7 +293,8 @@
        (insert "\n")
        (if tomatinho-display-tubes
 	   (tomatinho-display-tubes)
-	 (tomatinho-display-history))))))
+	 (tomatinho-display-history)))))
+  (run-hooks 'tomatinho-update-hook))
 
 ;;;;;;;;;;;;;;;;;;;
 ;; Main function ;;


### PR DESCRIPTION
I wanted to set desktop notification and didn't find a proper way. So I added this simple hook which can be used in many different ways. The most obvious way is to show a notification if one need it.